### PR TITLE
Release/0.7.3

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,11 +22,13 @@ These are my notes on the development of the plugin.
 
 ## Development Diary
 
-### 14. September 2025
+### 27. September 2025
 
 Unicode characters can be defined by multiple parts, which makes the string length in JavaScript larger than 1.
-The "NFC" normalization is now applied to the string, which makes the maximum length of the string equal to 2.
-I fixed it thanks to https://dietcode.io/p/unicode-normalization/.
+I thought the "NFC" normalization limited the string to a length of 2, but that is not the case.
+The character `U+FB2C` has a length of 3, see issue #15.
+The "NFC" normalization is still applied, but I don't believe it will guarantee any maximum length of the string.
+Fixed in part thanks to https://dietcode.io/p/unicode-normalization/.
 
 ### 22. April 2025
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    modulePaths: [
+        "<rootDir>"
+    ]
 };

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "unicode-search",
 	"name": "Unicode Search",
-	"version": "0.7.2-NEXT",
+	"version": "0.7.3",
 	"minAppVersion": "1.8.7",
 	"description": "Search and insert Unicode characters into your editor",
 	"author": "BambusControl",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "unicode-search",
 	"name": "Unicode Search",
-	"version": "0.7.2",
+	"version": "0.7.2-NEXT",
 	"minAppVersion": "1.8.7",
 	"description": "Search and insert Unicode characters into your editor",
 	"author": "BambusControl",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-unicode-search",
-  "version": "0.7.2-NEXT",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-unicode-search",
-      "version": "0.7.2-NEXT",
+      "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "papaparse": "^5.5.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-unicode-search",
-  "version": "0.7.2",
+  "version": "0.7.2-NEXT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-unicode-search",
-      "version": "0.7.2",
+      "version": "0.7.2-NEXT",
       "license": "Apache-2.0",
       "dependencies": {
         "papaparse": "^5.5.1"
@@ -1040,9 +1040,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1069,14 +1069,14 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -1084,10 +1084,21 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1099,9 +1110,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -1124,20 +1135,23 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1146,13 +1160,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
+        "@eslint/core": "^0.15.2",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1216,9 +1231,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -2413,9 +2428,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2494,9 +2509,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2773,9 +2788,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3336,23 +3351,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.35.0",
+        "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -3360,9 +3376,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -3397,9 +3413,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -3428,9 +3444,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -3442,16 +3458,16 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3461,9 +3477,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -3686,9 +3702,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3959,9 +3975,9 @@
       "license": "MIT"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-unicode-search",
-  "version": "0.7.2",
+  "version": "0.7.2-NEXT",
   "description": "Obsidian plugin for searching Unicode characters.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "export-schema": "typescript-json-schema --required --strictNullChecks --validationKeywords --ignoreErrors --refs --id https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json --out ./resources/save-data-schema.json tsconfig.json SaveData",
+    "export-schema": "typescript-json-schema --required --strictNullChecks --validationKeywords --ignoreErrors --refs --id https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2-NEXT/resources/save-data-schema.json --out ./resources/save-data-schema.json tsconfig.json SaveData",
     "test": "jest"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-unicode-search",
-  "version": "0.7.2-NEXT",
+  "version": "0.7.3",
   "description": "Obsidian plugin for searching Unicode characters.",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
-    "export-schema": "typescript-json-schema --required --strictNullChecks --validationKeywords --ignoreErrors --refs --id https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2-NEXT/resources/save-data-schema.json --out ./resources/save-data-schema.json tsconfig.json SaveData",
+    "export-schema": "typescript-json-schema --required --strictNullChecks --validationKeywords --ignoreErrors --refs --id https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json --out ./resources/save-data-schema.json tsconfig.json SaveData",
     "test": "jest"
   },
   "keywords": [

--- a/resources/save-data-schema.json
+++ b/resources/save-data-schema.json
@@ -1,14 +1,14 @@
 {
-    "$id": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json",
+    "$id": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "BlockFilter": {
             "allOf": [
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CodepointInterval"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CodepointInterval"
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/InclusionFlag"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/InclusionFlag"
                 }
             ],
             "description": "Block of Unicode Codepoints"
@@ -17,8 +17,8 @@
             "description": "Filter for a single category.",
             "properties": {
                 "abbreviation": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CharacterCategoryType",
-                    "description": "Two letter abbreviation of the category."
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CharacterCategoryType",
+                    "description": "Two-letter abbreviation of the category."
                 },
                 "included": {
                     "description": "Indicates whether a character is included in search or not",
@@ -35,13 +35,13 @@
             "description": "Filters for a group of categories.",
             "properties": {
                 "abbreviation": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CharacterCategoryGroupType",
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CharacterCategoryGroupType",
                     "description": "Single letter abbreviation of the category group."
                 },
                 "categories": {
                     "description": "Categories which belong to the group.",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CategoryFilter"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CategoryFilter"
                     },
                     "type": "array"
                 }
@@ -105,7 +105,7 @@
                 "codepoints": {
                     "description": "Statistics of the individual codepoint usage",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/RawCodepointUse"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/RawCodepointUse"
                     },
                     "type": "array"
                 },
@@ -113,7 +113,7 @@
                     "type": "boolean"
                 },
                 "version": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/SaveDataVersion"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/SaveDataVersion"
                 }
             },
             "required": [
@@ -131,7 +131,7 @@
                     "type": "string"
                 },
                 "name": {
-                    "description": "Unicode provided description of the character",
+                    "description": "Unicode description of the character",
                     "type": "string"
                 }
             },
@@ -161,8 +161,7 @@
             "description": "Universally used key for a Unicode codepoint",
             "properties": {
                 "codepoint": {
-                    "description": "A single Unicode code point character defined by its normalized NFC form",
-                    "maxLength": 2,
+                    "description": "Unicode code point character defined by its normalized NFC form",
                     "minLength": 1,
                     "type": "string"
                 }
@@ -196,7 +195,7 @@
                 "codepoints": {
                     "description": "List of favorite codepoints",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/RawCodepointFavorite"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/RawCodepointFavorite"
                     },
                     "type": "array"
                 },
@@ -204,7 +203,7 @@
                     "type": "boolean"
                 },
                 "version": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/SaveDataVersion"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/SaveDataVersion"
                 }
             },
             "required": [
@@ -221,11 +220,11 @@
                     "type": "boolean"
                 },
                 "unicode": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/UnicodeFilter",
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/UnicodeFilter",
                     "description": "Filter criteria for Unicode characters"
                 },
                 "version": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/SaveDataVersion"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/SaveDataVersion"
                 }
             },
             "required": [
@@ -263,11 +262,11 @@
                     "type": "boolean"
                 },
                 "pluginVersion": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/PluginVersion",
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/PluginVersion",
                     "description": "Latest used version of the plugin which used this data"
                 },
                 "version": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/SaveDataVersion"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/SaveDataVersion"
                 }
             },
             "required": [
@@ -284,7 +283,7 @@
                 "blocks": {
                     "description": "Filter criteria for blocks of Unicode characters",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/BlockFilter"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/BlockFilter"
                     },
                     "type": "array"
                 },
@@ -317,17 +316,18 @@
                 "0.6.1",
                 "0.7.0",
                 "0.7.1",
-                "0.7.2"
+                "0.7.2",
+                "0.7.3"
             ],
             "type": "string"
         },
         "RawCodepointFavorite": {
             "allOf": [
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CodepointKey"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CodepointKey"
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/FavoriteInfo"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/FavoriteInfo"
                 }
             ],
             "description": "Favorite infor of a specific codepoint as stored in save data"
@@ -335,10 +335,10 @@
         "RawCodepointUse": {
             "allOf": [
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CodepointKey"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CodepointKey"
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/RawUsageInfo"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/RawUsageInfo"
                 }
             ],
             "description": "Usage information of a specific codepoint as stored in save data"
@@ -378,10 +378,10 @@
         "UnicodeCodepoint": {
             "allOf": [
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CodepointKey"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CodepointKey"
                 },
                 {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CodepointAttribute"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CodepointAttribute"
                 }
             ],
             "description": "Unicode codepoint representation throughout the plugin"
@@ -392,14 +392,14 @@
                 "categoryGroups": {
                     "description": "Filter criteria for category groups of Unicode characters",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CategoryGroupFilter"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CategoryGroupFilter"
                     },
                     "type": "array"
                 },
                 "planes": {
                     "description": "Filter criteria for planes of Unicode characters",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/PlaneFilter"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/PlaneFilter"
                     },
                     "type": "array"
                 }
@@ -416,7 +416,7 @@
                 "codepoints": {
                     "description": "Codepoints downloaded from the Unicode Character Database",
                     "items": {
-                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/UnicodeCodepoint"
+                        "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/UnicodeCodepoint"
                     },
                     "type": "array"
                 },
@@ -424,7 +424,7 @@
                     "type": "boolean"
                 },
                 "version": {
-                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/SaveDataVersion"
+                    "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/SaveDataVersion"
                 }
             },
             "required": [
@@ -438,23 +438,23 @@
     "description": "Structure of `data.json`, where each fragment is a self-managed data fragment",
     "properties": {
         "characters": {
-            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/UnicodeFragment",
+            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/UnicodeFragment",
             "description": "Local character database"
         },
         "favorites": {
-            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/FavoritesFragment",
+            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/FavoritesFragment",
             "description": "Favorites saved manually by the user"
         },
         "filter": {
-            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/FilterFragment",
+            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/FilterFragment",
             "description": "Filtering of downloaded/displayed codepoints"
         },
         "meta": {
-            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/MetaFragment",
+            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/MetaFragment",
             "description": "Metadata information about the save data itself"
         },
         "usage": {
-            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.2/resources/save-data-schema.json#/definitions/CharacterUseFragment",
+            "$ref": "https://raw.githubusercontent.com/BambusControl/obsidian-unicode-search/0.7.3/resources/save-data-schema.json#/definitions/CharacterUseFragment",
             "description": "Usage information generated by the user"
         }
     },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=BambusControl_obsidian-unicode-search
 sonar.organization=bambuscontrol
 
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectVersion=0.7.2
+sonar.projectVersion=0.7.2-NEXT
 
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=BambusControl_obsidian-unicode-search
 sonar.organization=bambuscontrol
 
 # This is the name and version displayed in the SonarCloud UI.
-sonar.projectVersion=0.7.2-NEXT
+sonar.projectVersion=0.7.3
 
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.

--- a/src/libraries/helpers/isTypeSaveData.ts
+++ b/src/libraries/helpers/isTypeSaveData.ts
@@ -19,6 +19,5 @@ export function isCodepointKey(object: any): object is CodepointKey {
 export function isChar(object: any): object is Char {
     return object != null
         && typeof object === "string"
-        /* In the NCD form the database has a codepoint max length of two characters */
-        && object.length <=2
+        ;
 }

--- a/src/libraries/helpers/matchedNameOrCodepoint.ts
+++ b/src/libraries/helpers/matchedNameOrCodepoint.ts
@@ -1,4 +1,7 @@
-import {MaybeMetaCharacterSearchResult, MetaCharacterSearchResult} from "../../unicode-search/components/characterSearch";
+import {
+    MaybeMetaCharacterSearchResult,
+    MetaCharacterSearchResult
+} from "../../unicode-search/components/characterSearch";
 
 export function matchedNameOrCodepoint(match: MetaCharacterSearchResult | MaybeMetaCharacterSearchResult) {
     return match.match.name != null || match.match.codepoint != null;

--- a/src/libraries/helpers/parseUsageInfo.ts
+++ b/src/libraries/helpers/parseUsageInfo.ts
@@ -1,4 +1,4 @@
-import {UsageInfo, RawUsageInfo} from "../types/savedata/usageInfo";
+import {RawUsageInfo, UsageInfo} from "../types/savedata/usageInfo";
 
 export function parseUsageInfo<T>(value: T & RawUsageInfo): T & UsageInfo {
     return {

--- a/src/libraries/helpers/serializeUsageInfo.ts
+++ b/src/libraries/helpers/serializeUsageInfo.ts
@@ -1,4 +1,4 @@
-import {UsageInfo, RawUsageInfo} from "../types/savedata/usageInfo";
+import {RawUsageInfo, UsageInfo} from "../types/savedata/usageInfo";
 
 export function serializeUsageInfo<T>(value: T & UsageInfo): T & RawUsageInfo {
     return {

--- a/src/libraries/helpers/toHexadecimal.ts
+++ b/src/libraries/helpers/toHexadecimal.ts
@@ -3,6 +3,10 @@ import {asHexadecimal} from "./asHexadecimal";
 import {CodepointKey} from "../types/codepoint/unicode";
 
 export function toHexadecimal(character: CodepointKey): string {
-    /* Characters are expected to always have a single character */
+    /* Characters are expected to always have at least a single character
+     *
+     * Unicode codepoints may be multiple string characters; however, codePointAt will handle most of the cases.
+     * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters
+     */
     return asHexadecimal(character.codepoint.codePointAt(0)!);
 }

--- a/src/libraries/types/codepoint/character.ts
+++ b/src/libraries/types/codepoint/character.ts
@@ -1,7 +1,6 @@
 import {UnicodeCodepoint} from "./unicode";
 
 
-
 import {ParsedFavoriteInfo} from "../savedata/favoriteInfo";
 import {UsageInfo} from "../savedata/usageInfo";
 

--- a/src/libraries/types/codepoint/extension.ts
+++ b/src/libraries/types/codepoint/extension.ts
@@ -1,5 +1,5 @@
 import {FavoriteInfo as RawFavoriteInfo, ParsedFavoriteInfo as FavoriteInfo} from "../savedata/favoriteInfo";
-import {UsageInfo as UseInfo, RawUsageInfo as RawUseInfo} from "../savedata/usageInfo";
+import {RawUsageInfo as RawUseInfo, UsageInfo as UseInfo} from "../savedata/usageInfo";
 import {CodepointKey} from "./unicode";
 
 /**

--- a/src/libraries/types/codepoint/unicode.ts
+++ b/src/libraries/types/codepoint/unicode.ts
@@ -1,4 +1,8 @@
+/**
+ * Unicode code point character defined by its normalized NFC form
+ */
 export type Char = string
+
 export type Codepoint = number;
 
 /**
@@ -6,8 +10,7 @@ export type Codepoint = number;
  */
 export interface CodepointKey {
     /**
-     * A single Unicode code point character defined by its normalized NFC form
-     * @maxLength 2
+     * Unicode code point character defined by its normalized NFC form
      * @minLength 1
      */
     codepoint: Char;
@@ -18,7 +21,7 @@ export interface CodepointKey {
  */
 export interface CodepointAttribute {
     /**
-     * Unicode provided description of the character
+     * Unicode description of the character
      */
     name: string;
 

--- a/src/libraries/types/savedata/metaFragment.ts
+++ b/src/libraries/types/savedata/metaFragment.ts
@@ -1,5 +1,5 @@
 import {DataFragment} from "./dataFragment";
-import { PluginVersion } from "./version";
+import {PluginVersion} from "./version";
 
 /**
  * Meta information for the datastore

--- a/src/libraries/types/savedata/saveData.ts
+++ b/src/libraries/types/savedata/saveData.ts
@@ -3,7 +3,7 @@ import {UnicodeFragment} from "./unicodeFragment";
 import {CharacterUseFragment as UsageFragment} from "./usageFragment";
 import {FavoritesFragment} from "./favoritesFragment";
 import {MetaFragment} from "./metaFragment";
-import { DataFragment } from "./dataFragment";
+import {DataFragment} from "./dataFragment";
 
 /**
  * Generic structure of `data.json`

--- a/src/libraries/types/savedata/unicodeFilter.ts
+++ b/src/libraries/types/savedata/unicodeFilter.ts
@@ -64,7 +64,7 @@ export interface CategoryGroupFilter {
  */
 export interface CategoryFilter extends InclusionFlag {
     /**
-     * Two letter abbreviation of the category.
+     * Two-letter abbreviation of the category.
      * @maxLength 2
      * @minLength 2
      */

--- a/src/libraries/types/savedata/version.ts
+++ b/src/libraries/types/savedata/version.ts
@@ -18,11 +18,12 @@ export type PluginVersion
     | "0.7.0"
     | "0.7.1"
     | "0.7.2"
+    | "0.7.2-NEXT"
     // Update every release
     ;
 
-export type CurrentPluginVersion = "0.7.2" & PluginVersion;
-export const CURRENT_PLUGIN_VERSION: CurrentPluginVersion = "0.7.2";
+export type CurrentPluginVersion = "0.7.2-NEXT" & PluginVersion;
+export const CURRENT_PLUGIN_VERSION: CurrentPluginVersion = "0.7.2-NEXT";
 
 /**
  * Version of the save data schema.

--- a/src/libraries/types/savedata/version.ts
+++ b/src/libraries/types/savedata/version.ts
@@ -18,12 +18,12 @@ export type PluginVersion
     | "0.7.0"
     | "0.7.1"
     | "0.7.2"
-    | "0.7.2-NEXT"
+    | "0.7.3"
     // Update every release
     ;
 
-export type CurrentPluginVersion = "0.7.2-NEXT" & PluginVersion;
-export const CURRENT_PLUGIN_VERSION: CurrentPluginVersion = "0.7.2-NEXT";
+export type CurrentPluginVersion = "0.7.3" & PluginVersion;
+export const CURRENT_PLUGIN_VERSION: CurrentPluginVersion = "0.7.3";
 
 /**
  * Version of the save data schema.

--- a/src/unicode-search/service/favoritesStore.ts
+++ b/src/unicode-search/service/favoritesStore.ts
@@ -1,4 +1,4 @@
-import { CharacterKey } from "../../libraries/types/codepoint/character";
+import {CharacterKey} from "../../libraries/types/codepoint/character";
 
 import {CodepointFavorite} from "../../libraries/types/codepoint/extension";
 import {ParsedFavoriteInfo} from "../../libraries/types/savedata/favoriteInfo";

--- a/src/unicode-search/service/rootDataManager.ts
+++ b/src/unicode-search/service/rootDataManager.ts
@@ -1,9 +1,6 @@
 import {FilterDataManager} from "./filterDataManager";
 import {PersistCache} from "../../libraries/types/persistCache";
-import {
-    SaveData,
-    SaveDataOf
-} from "../../libraries/types/savedata/saveData";
+import {SaveData, SaveDataOf} from "../../libraries/types/savedata/saveData";
 import {UnicodeDataManager} from "./unicodeDataManager";
 import {UsageDataManager} from "./usageDataManager";
 import {FavoritesDataManager} from "./favoritesDataManager";

--- a/src/unicode-search/service/userCharacterService.ts
+++ b/src/unicode-search/service/userCharacterService.ts
@@ -1,7 +1,9 @@
 import {UnicodeSearchError} from "../errors/unicodeSearchError";
 import {
     Character,
-    CharacterKey, FavoriteCharacter, MaybeUsedCharacter,
+    CharacterKey,
+    FavoriteCharacter,
+    MaybeUsedCharacter,
     UsedCharacter
 } from "../../libraries/types/codepoint/character";
 import {CodepointStore} from "./codePointStore";

--- a/tests/libraries/comparison/compareCharacterMatches.spec.ts
+++ b/tests/libraries/comparison/compareCharacterMatches.spec.ts
@@ -1,0 +1,52 @@
+import {expect, test} from "@jest/globals";
+import {compareCharacterMatches} from "src/libraries/comparison/compareCharacterMatches";
+import {Order} from "src/libraries/order/order";
+
+test(
+    "better match is before worse match",
+    () => {
+        const betterMatch = {
+            character: { codepoint: "A", name: "LATIN CAPITAL LETTER A", category: "Lu" },
+            match: { codepoint: { score: 0, matches: [] }, name: { score: 0, matches: [] } }
+        };
+        const worseMatch = {
+            character: { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" },
+            match: { codepoint: { score: -0.5, matches: [] }, name: { score: -0.5, matches: [] } }
+        };
+
+        expect(compareCharacterMatches(betterMatch, worseMatch, new Date(0))).toBe(Order.Before);
+    }
+)
+
+test(
+    "worse match is after better match",
+    () => {
+        const worseMatch = {
+            character: { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" },
+            match: { codepoint: { score: -0.5, matches: [] }, name: { score: -0.5, matches: [] } }
+        };
+        const betterMatch = {
+            character: { codepoint: "A", name: "LATIN CAPITAL LETTER A", category: "Lu" },
+            match: { codepoint: { score: 0, matches: [] }, name: { score: 0, matches: [] } }
+        };
+
+        expect(compareCharacterMatches(worseMatch, betterMatch, new Date(0))).toBe(Order.After);
+    }
+)
+
+test(
+    "different match scores compare correctly",
+    () => {
+        const matchA = {
+            character: { codepoint: "A", name: "LATIN CAPITAL LETTER A", category: "Lu" },
+            match: { codepoint: { score: -0.3, matches: [] }, name: { score: -0.5, matches: [] } }
+        };
+        const matchB = {
+            character: { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" },
+            match: { codepoint: { score: -0.6, matches: [] }, name: { score: -0.4, matches: [] } }
+        };
+
+        // matchA total: -0.8, matchB total: -1.0, so matchA should be before matchB (better score)
+        expect(compareCharacterMatches(matchA, matchB, new Date(0))).toBe(Order.Before);
+    }
+)

--- a/tests/libraries/comparison/compareCharacters.spec.ts
+++ b/tests/libraries/comparison/compareCharacters.spec.ts
@@ -1,0 +1,63 @@
+import {expect, test} from "@jest/globals";
+import {compareCharacters} from "src/libraries/comparison/compareCharacters";
+import {Order} from "src/libraries/order/order";
+
+test(
+    "used character is before unused character",
+    () => {
+        const usedChar = {
+            codepoint: "A",
+            name: "LATIN CAPITAL LETTER A",
+            category: "Lu",
+            useCount: 1,
+            firstUsed: new Date(0),
+            lastUsed: new Date(1)
+        };
+        const unusedChar = { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" };
+
+        expect(compareCharacters(usedChar, unusedChar, new Date(0))).toBe(Order.Before);
+    }
+)
+
+test(
+    "unused character is after used character",
+    () => {
+        const unusedChar = { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" };
+        const usedChar = {
+            codepoint: "A",
+            name: "LATIN CAPITAL LETTER A",
+            category: "Lu",
+            useCount: 1,
+            firstUsed: new Date(0),
+            lastUsed: new Date(1)
+        };
+
+        expect(compareCharacters(unusedChar, usedChar, new Date(0))).toBe(Order.After);
+    }
+)
+
+test(
+    "favorite character is before non-favorite when usage is equal",
+    () => {
+        const favoriteChar = {
+            codepoint: "A",
+            name: "LATIN CAPITAL LETTER A",
+            category: "Lu",
+            isFavorite: true,
+            favoriteCreated: new Date(0)
+        };
+        const normalChar = { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" };
+
+        expect(compareCharacters(favoriteChar, normalChar, new Date(0))).toBe(Order.Before);
+    }
+)
+
+test(
+    "earlier codepoint is before later codepoint when all else equal",
+    () => {
+        const charA = { codepoint: "A", name: "LATIN CAPITAL LETTER A", category: "Lu" };
+        const charB = { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" };
+
+        expect(compareCharacters(charA, charB, new Date(0))).toBe(Order.Before);
+    }
+)

--- a/tests/libraries/comparison/compareCodepoints.spec.ts
+++ b/tests/libraries/comparison/compareCodepoints.spec.ts
@@ -1,4 +1,4 @@
-import {compareCodepoints} from "../../../src/libraries/comparison/compareCodepoints";
+import {compareCodepoints} from "src/libraries/comparison/compareCodepoints";
 
 test(
     "character with codepoint `a` is before character with codepoint `b`",

--- a/tests/libraries/comparison/compareDates.test.ts
+++ b/tests/libraries/comparison/compareDates.test.ts
@@ -1,5 +1,5 @@
-import { compareDates } from "../../../src/libraries/comparison/compareDates";
-import { Order } from "../../../src/libraries/order/order";
+import { compareDates } from "src/libraries/comparison/compareDates";
+import { Order } from "src/libraries/order/order";
 
 describe("compareDates", () => {
     it("should return Order.Smaller when the left date is earlier than the right date", () => {

--- a/tests/libraries/comparison/compareFavoriteCharacters.spec.ts
+++ b/tests/libraries/comparison/compareFavoriteCharacters.spec.ts
@@ -1,4 +1,4 @@
-import {compareFavoriteCharacters} from "../../../src/libraries/comparison/compareFavoriteCharacters";
+import {compareFavoriteCharacters} from "src/libraries/comparison/compareFavoriteCharacters";
 
 test(
     "character which is `favorite` is before character which is not",

--- a/tests/libraries/comparison/compareFavoriteInfo.spec.ts
+++ b/tests/libraries/comparison/compareFavoriteInfo.spec.ts
@@ -1,4 +1,4 @@
-import {compareFavoriteInfo} from "../../../src/libraries/comparison/compareFavoriteInfo";
+import {compareFavoriteInfo} from "src/libraries/comparison/compareFavoriteInfo";
 
 test(
 	"later added is before sooner added",

--- a/tests/libraries/comparison/compareNullable.spec.ts
+++ b/tests/libraries/comparison/compareNullable.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from "@jest/globals";
-import {compareNullable} from "../../../src/libraries/comparison/compareNullable";
-import {compareNumbers} from "../../../src/libraries/comparison/compareNumbers";
+import {compareNullable} from "src/libraries/comparison/compareNullable";
+import {compareNumbers} from "src/libraries/comparison/compareNumbers";
 
 test(
     "null equals null",

--- a/tests/libraries/comparison/compareNumbers.spec.ts
+++ b/tests/libraries/comparison/compareNumbers.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from "@jest/globals";
-import {compareNumbers} from "../../../src/libraries/comparison/compareNumbers";
+import {compareNumbers} from "src/libraries/comparison/compareNumbers";
 
 test(
     "one equals one",

--- a/tests/libraries/comparison/compareSearchMatchScores.spec.ts
+++ b/tests/libraries/comparison/compareSearchMatchScores.spec.ts
@@ -1,0 +1,52 @@
+import {expect, test} from "@jest/globals";
+import {compareSearchMatchScores} from "src/libraries/comparison/compareSearchMatchScores";
+import {Order} from "src/libraries/order/order";
+
+test(
+    "better combined score is before worse combined score",
+    () => {
+        const betterMatch = {
+            codepoint: { score: 0, matches: [] },
+            name: { score: 0, matches: [] }
+        };
+        const worseMatch = {
+            codepoint: { score: -0.5, matches: [] },
+            name: { score: -0.5, matches: [] }
+        };
+
+        expect(compareSearchMatchScores(betterMatch, worseMatch)).toBe(Order.Before);
+    }
+)
+
+test(
+    "worse combined score is after better combined score",
+    () => {
+        const worseMatch = {
+            codepoint: { score: -0.5, matches: [] },
+            name: { score: -0.5, matches: [] }
+        };
+        const betterMatch = {
+            codepoint: { score: 0, matches: [] },
+            name: { score: 0, matches: [] }
+        };
+
+        expect(compareSearchMatchScores(worseMatch, betterMatch)).toBe(Order.After);
+    }
+)
+
+test(
+    "truly equal combined scores return NaN (which is handled by caller)",
+    () => {
+        const match1 = {
+            codepoint: { score: -0.2, matches: [] },
+            name: { score: -0.3, matches: [] }
+        };
+        const match2 = {
+            codepoint: { score: -0.2, matches: [] },
+            name: { score: -0.3, matches: [] }
+        };
+
+        // When scores are exactly equal, division by 0 results in NaN
+        expect(isNaN(compareSearchMatchScores(match1, match2))).toBe(true);
+    }
+)

--- a/tests/libraries/comparison/compareSearchMatches.spec.ts
+++ b/tests/libraries/comparison/compareSearchMatches.spec.ts
@@ -1,0 +1,55 @@
+import {expect, test} from "@jest/globals";
+import {compareSearchMatches} from "src/libraries/comparison/compareSearchMatches";
+import {Order} from "src/libraries/order/order";
+
+test(
+    "both null matches are equal",
+    () => {
+        const nullMatch1 = { codepoint: null, name: null };
+        const nullMatch2 = { codepoint: null, name: null };
+
+        expect(compareSearchMatches(nullMatch1, nullMatch2)).toBe(Order.Equal);
+    }
+)
+
+test(
+    "non-null match is before null match",
+    () => {
+        const realMatch = {
+            codepoint: { score: 0, matches: [] },
+            name: { score: 0, matches: [] }
+        };
+        const nullMatch = { codepoint: null, name: null };
+
+        expect(compareSearchMatches(realMatch, nullMatch)).toBe(Order.Before);
+    }
+)
+
+test(
+    "null match is after non-null match",
+    () => {
+        const nullMatch = { codepoint: null, name: null };
+        const realMatch = {
+            codepoint: { score: 0, matches: [] },
+            name: { score: 0, matches: [] }
+        };
+
+        expect(compareSearchMatches(nullMatch, realMatch)).toBe(Order.After);
+    }
+)
+
+test(
+    "better score is before worse score",
+    () => {
+        const betterMatch = {
+            codepoint: { score: 0, matches: [] },
+            name: { score: 0, matches: [] }
+        };
+        const worseMatch = {
+            codepoint: { score: -0.5, matches: [] },
+            name: { score: -0.5, matches: [] }
+        };
+
+        expect(compareSearchMatches(betterMatch, worseMatch)).toBe(Order.Before);
+    }
+)

--- a/tests/libraries/comparison/compareUsageInfo.spec.ts
+++ b/tests/libraries/comparison/compareUsageInfo.spec.ts
@@ -1,4 +1,4 @@
-import {compareUsageInfo} from "../../../src/libraries/comparison/compareUsageInfo";
+import {compareUsageInfo} from "src/libraries/comparison/compareUsageInfo";
 
 test(
 	"later use is before sooner use",

--- a/tests/libraries/comparison/compareUsedCharacters.spec.ts
+++ b/tests/libraries/comparison/compareUsedCharacters.spec.ts
@@ -1,4 +1,4 @@
-import {compareUsedCharacters} from "../../../src/libraries/comparison/compareUsedCharacters";
+import {compareUsedCharacters} from "src/libraries/comparison/compareUsedCharacters";
 
 test(
     "character with `use` is before character without",

--- a/tests/libraries/comparison/fillNullCharacterMatchScores.spec.ts
+++ b/tests/libraries/comparison/fillNullCharacterMatchScores.spec.ts
@@ -1,0 +1,54 @@
+import {expect, test} from "@jest/globals";
+import {fillNullCharacterMatchScores} from "src/libraries/comparison/fillNullCharacterMatchScores";
+import {NONE_RESULT} from "src/unicode-search/components/characterSearch";
+
+test(
+    "fills null match attributes while preserving character",
+    () => {
+        const input = {
+            character: { codepoint: "A", name: "LATIN CAPITAL LETTER A", category: "Lu" },
+            match: { codepoint: null, name: { score: -0.5, matches: [] } }
+        };
+
+        const result = fillNullCharacterMatchScores(input);
+
+        expect(result.character).toEqual(input.character);
+        expect(result.match.codepoint).toBe(NONE_RESULT);
+        expect(result.match.name).toEqual({ score: -0.5, matches: [] });
+    }
+)
+
+test(
+    "fills all null match attributes",
+    () => {
+        const input = {
+            character: { codepoint: "B", name: "LATIN CAPITAL LETTER B", category: "Lu" },
+            match: { codepoint: null, name: null }
+        };
+
+        const result = fillNullCharacterMatchScores(input);
+
+        expect(result.character).toEqual(input.character);
+        expect(result.match.codepoint).toBe(NONE_RESULT);
+        expect(result.match.name).toBe(NONE_RESULT);
+    }
+)
+
+test(
+    "preserves non-null match attributes",
+    () => {
+        const input = {
+            character: { codepoint: "C", name: "LATIN CAPITAL LETTER C", category: "Lu" },
+            match: {
+                codepoint: { score: -0.2, matches: [] },
+                name: { score: -0.3, matches: [] }
+            }
+        };
+
+        const result = fillNullCharacterMatchScores(input);
+
+        expect(result.character).toEqual(input.character);
+        expect(result.match.codepoint).toEqual({ score: -0.2, matches: [] });
+        expect(result.match.name).toEqual({ score: -0.3, matches: [] });
+    }
+)

--- a/tests/libraries/comparison/fillNullSearchMatchScores.spec.ts
+++ b/tests/libraries/comparison/fillNullSearchMatchScores.spec.ts
@@ -1,0 +1,63 @@
+import {expect, test} from "@jest/globals";
+import {fillNullSearchMatchScores} from "src/libraries/comparison/fillNullSearchMatchScores";
+import {NONE_RESULT} from "src/unicode-search/components/characterSearch";
+
+test(
+    "fills null codepoint with NONE_RESULT",
+    () => {
+        const input = {
+            codepoint: null,
+            name: { score: -0.5, matches: [] }
+        };
+
+        const result = fillNullSearchMatchScores(input);
+
+        expect(result.codepoint).toBe(NONE_RESULT);
+        expect(result.name).toEqual({ score: -0.5, matches: [] });
+    }
+)
+
+test(
+    "fills null name with NONE_RESULT",
+    () => {
+        const input = {
+            codepoint: { score: -0.5, matches: [] },
+            name: null
+        };
+
+        const result = fillNullSearchMatchScores(input);
+
+        expect(result.codepoint).toEqual({ score: -0.5, matches: [] });
+        expect(result.name).toBe(NONE_RESULT);
+    }
+)
+
+test(
+    "fills both null values with NONE_RESULT",
+    () => {
+        const input = {
+            codepoint: null,
+            name: null
+        };
+
+        const result = fillNullSearchMatchScores(input);
+
+        expect(result.codepoint).toBe(NONE_RESULT);
+        expect(result.name).toBe(NONE_RESULT);
+    }
+)
+
+test(
+    "preserves non-null values",
+    () => {
+        const input = {
+            codepoint: { score: -0.2, matches: [] },
+            name: { score: -0.3, matches: [] }
+        };
+
+        const result = fillNullSearchMatchScores(input);
+
+        expect(result.codepoint).toEqual({ score: -0.2, matches: [] });
+        expect(result.name).toEqual({ score: -0.3, matches: [] });
+    }
+)

--- a/tests/libraries/helpers/asHexadecimal.spec.ts
+++ b/tests/libraries/helpers/asHexadecimal.spec.ts
@@ -1,0 +1,42 @@
+import { asHexadecimal } from "src/libraries/helpers/asHexadecimal";
+
+describe("asHexadecimal", () => {
+    it("should convert single digit numbers to 4-character hex strings", () => {
+        expect(asHexadecimal(0)).toBe("0000");
+        expect(asHexadecimal(1)).toBe("0001");
+        expect(asHexadecimal(9)).toBe("0009");
+    });
+
+    it("should convert two digit numbers to 4-character hex strings", () => {
+        expect(asHexadecimal(10)).toBe("000a");
+        expect(asHexadecimal(15)).toBe("000f");
+        expect(asHexadecimal(16)).toBe("0010");
+        expect(asHexadecimal(99)).toBe("0063");
+    });
+
+    it("should convert three digit numbers to 4-character hex strings", () => {
+        expect(asHexadecimal(100)).toBe("0064");
+        expect(asHexadecimal(255)).toBe("00ff");
+        expect(asHexadecimal(256)).toBe("0100");
+        expect(asHexadecimal(999)).toBe("03e7");
+    });
+
+    it("should convert four digit numbers to 4-character hex strings", () => {
+        expect(asHexadecimal(1000)).toBe("03e8");
+        expect(asHexadecimal(4095)).toBe("0fff");
+        expect(asHexadecimal(4096)).toBe("1000");
+        expect(asHexadecimal(9999)).toBe("270f");
+    });
+
+    it("should handle larger numbers (more than 4 hex digits)", () => {
+        expect(asHexadecimal(65536)).toBe("10000");
+        expect(asHexadecimal(1048576)).toBe("100000");
+    });
+
+    it("should handle common Unicode code points", () => {
+        expect(asHexadecimal(65)).toBe("0041"); // 'A'
+        expect(asHexadecimal(97)).toBe("0061"); // 'a'
+        expect(asHexadecimal(32)).toBe("0020"); // space
+        expect(asHexadecimal(8364)).toBe("20ac"); // '€'
+    });
+});

--- a/tests/libraries/helpers/averageUseCount.spec.ts
+++ b/tests/libraries/helpers/averageUseCount.spec.ts
@@ -1,4 +1,4 @@
-import { averageUseCount } from "../../../src/libraries/helpers/averageUseCount";
+import { averageUseCount } from "src/libraries/helpers/averageUseCount";
 
 describe("averageUseCount", () => {
     it("should return 0 when the input array is empty", () => {

--- a/tests/libraries/helpers/codePointIn.spec.ts
+++ b/tests/libraries/helpers/codePointIn.spec.ts
@@ -1,6 +1,6 @@
-import { codepointIn } from "../../../src/libraries/helpers/codePointIn";
-import { Codepoint } from "../../../src/libraries/types/codepoint/unicode";
-import { CodepointInterval } from "../../../src/libraries/types/codepoint/codepointInterval";
+import { codepointIn } from "src/libraries/helpers/codePointIn";
+import { Codepoint } from "src/libraries/types/codepoint/unicode";
+import { CodepointInterval } from "src/libraries/types/codepoint/codepointInterval";
 
 describe("codepointIn", () => {
     it("should return true when the codepoint is within the interval", () => {

--- a/tests/libraries/helpers/getRandomItem.spec.ts
+++ b/tests/libraries/helpers/getRandomItem.spec.ts
@@ -1,0 +1,50 @@
+import { getRandomItem } from "src/libraries/helpers/getRandomItem";
+import { UnicodeSearchError } from "src/unicode-search/errors/unicodeSearchError";
+
+describe("getRandomItem", () => {
+    it("should throw UnicodeSearchError when array is empty", () => {
+        expect(() => getRandomItem([])).toThrow(UnicodeSearchError);
+        expect(() => getRandomItem([])).toThrow("Cannot get a random item from an empty array");
+    });
+
+    it("should return the only item when array has one element", () => {
+        const items = ["single"];
+        const result = getRandomItem(items);
+        expect(result).toBe("single");
+    });
+
+    it("should return one of the items when array has multiple elements", () => {
+        const items = ["a", "b", "c", "d", "e"];
+        const result = getRandomItem(items);
+        expect(items).toContain(result);
+    });
+
+    it("should work with different types", () => {
+        const numbers = [1, 2, 3, 4, 5];
+        const result = getRandomItem(numbers);
+        expect(numbers).toContain(result);
+        expect(typeof result).toBe("number");
+    });
+
+    it("should work with objects", () => {
+        const objects = [{ id: 1 }, { id: 2 }, { id: 3 }];
+        const result = getRandomItem(objects);
+        expect(objects).toContain(result);
+        expect(result).toHaveProperty("id");
+    });
+
+    it("should distribute across all items over multiple calls", () => {
+        const items = ["a", "b"];
+        const results = new Set<string>();
+
+        // Run enough times to statistically hit both items
+        for (let i = 0; i < 100; i++) {
+            results.add(getRandomItem(items));
+        }
+
+        // Should have hit both items at some point
+        expect(results.size).toBeGreaterThan(1);
+        expect(results.has("a")).toBe(true);
+        expect(results.has("b")).toBe(true);
+    });
+});

--- a/tests/libraries/helpers/hexadecimal.characters.spec.ts
+++ b/tests/libraries/helpers/hexadecimal.characters.spec.ts
@@ -1,4 +1,4 @@
-import {toHexadecimal} from "../../../src/libraries/helpers/toHexadecimal";
+import {toHexadecimal} from "src/libraries/helpers/toHexadecimal";
 
 test(
     "character `b` is `0062`",

--- a/tests/libraries/helpers/intervalWithin.spec.ts
+++ b/tests/libraries/helpers/intervalWithin.spec.ts
@@ -1,5 +1,5 @@
-import { intervalWithin } from "../../../src/libraries/helpers/intervalWithin";
-import { CodepointInterval } from "../../../src/libraries/types/codepoint/codepointInterval";
+import { intervalWithin } from "src/libraries/helpers/intervalWithin";
+import { CodepointInterval } from "src/libraries/types/codepoint/codepointInterval";
 
 describe("intervalWithin", () => {
     it("should return true when the inner interval is completely within the outer interval", () => {

--- a/tests/libraries/helpers/intervalsEqual.spec.ts
+++ b/tests/libraries/helpers/intervalsEqual.spec.ts
@@ -1,5 +1,5 @@
-import {intervalsEqual} from "../../../src/libraries/helpers/intervalsEqual";
-import {CodepointInterval} from "../../../src/libraries/types/codepoint/codepointInterval";
+import {intervalsEqual} from "src/libraries/helpers/intervalsEqual";
+import {CodepointInterval} from "src/libraries/types/codepoint/codepointInterval";
 
 describe("intervalsEqual", () => {
     it("should return true for intervals with the same start and end", () => {

--- a/tests/libraries/helpers/mergeIntervals.spec.ts
+++ b/tests/libraries/helpers/mergeIntervals.spec.ts
@@ -1,5 +1,5 @@
-import {CodepointInterval} from "../../../src/libraries/types/codepoint/codepointInterval";
-import {mergeIntervals} from "../../../src/libraries/helpers/mergeIntervals";
+import {CodepointInterval} from "src/libraries/types/codepoint/codepointInterval";
+import {mergeIntervals} from "src/libraries/helpers/mergeIntervals";
 
 describe("mergeIntervals", () => {
     it("should merge overlapping intervals", () => {

--- a/tests/libraries/helpers/mostRecentUses.spec.ts
+++ b/tests/libraries/helpers/mostRecentUses.spec.ts
@@ -1,0 +1,98 @@
+import { mostRecentUses } from "src/libraries/helpers/mostRecentUses";
+import { UsageDate } from "src/libraries/types/savedata/usageInfo";
+
+describe("mostRecentUses", () => {
+    it("should return empty array when input is empty", () => {
+        const result = mostRecentUses([]);
+        expect(result).toEqual([]);
+    });
+
+    it("should return single date when input has one item", () => {
+        const firstUsed = new Date("2022-12-31");
+        const lastUsed = new Date("2023-01-01");
+        const items: UsageDate[] = [{ firstUsed, lastUsed }];
+        const result = mostRecentUses(items);
+
+        expect(result).toEqual([lastUsed]);
+    });
+
+    it("should sort dates in descending order (most recent first)", () => {
+        const firstUsed = new Date("2022-12-31");
+        const date1 = new Date("2023-01-01");
+        const date2 = new Date("2023-01-02");
+        const date3 = new Date("2023-01-03");
+
+        const items: UsageDate[] = [
+            { firstUsed, lastUsed: date1 },
+            { firstUsed, lastUsed: date3 },
+            { firstUsed, lastUsed: date2 }
+        ];
+
+        const result = mostRecentUses(items);
+        expect(result).toEqual([date3, date2, date1]);
+    });
+
+    it("should handle items with same dates", () => {
+        const firstUsed = new Date("2022-12-31");
+        const date1 = new Date("2023-01-01");
+        const date2 = new Date("2023-01-02");
+
+        const items: UsageDate[] = [
+            { firstUsed, lastUsed: date1 },
+            { firstUsed, lastUsed: date2 },
+            { firstUsed, lastUsed: date1 },
+            { firstUsed, lastUsed: date2 }
+        ];
+
+        const result = mostRecentUses(items);
+        expect(result).toEqual([date2, date2, date1, date1]);
+    });
+
+    it("should not modify the original array", () => {
+        const firstUsed = new Date("2022-12-31");
+        const date1 = new Date("2023-01-01");
+        const date2 = new Date("2023-01-02");
+
+        const items: UsageDate[] = [
+            { firstUsed, lastUsed: date1 },
+            { firstUsed, lastUsed: date2 }
+        ];
+        const originalOrder = [...items];
+
+        mostRecentUses(items);
+
+        expect(items).toEqual(originalOrder);
+    });
+
+    it("should work with complex objects containing additional properties", () => {
+        const firstUsed = new Date("2022-12-31");
+        const date1 = new Date("2023-01-01");
+        const date2 = new Date("2023-01-02");
+        const date3 = new Date("2023-01-03");
+
+        const items = [
+            { firstUsed, lastUsed: date1, someOtherProp: "a" },
+            { firstUsed, lastUsed: date3, someOtherProp: "b" },
+            { firstUsed, lastUsed: date2, someOtherProp: "c" }
+        ];
+
+        const result = mostRecentUses(items);
+        expect(result).toEqual([date3, date2, date1]);
+    });
+
+    it("should handle dates with different times on the same day", () => {
+        const firstUsed = new Date("2022-12-31");
+        const date1 = new Date("2023-01-01T10:00:00Z");
+        const date2 = new Date("2023-01-01T12:00:00Z");
+        const date3 = new Date("2023-01-01T08:00:00Z");
+
+        const items: UsageDate[] = [
+            { firstUsed, lastUsed: date1 },
+            { firstUsed, lastUsed: date2 },
+            { firstUsed, lastUsed: date3 }
+        ];
+
+        const result = mostRecentUses(items);
+        expect(result).toEqual([date2, date1, date3]);
+    });
+});

--- a/tests/libraries/helpers/parseUsageInfo.spec.ts
+++ b/tests/libraries/helpers/parseUsageInfo.spec.ts
@@ -1,0 +1,89 @@
+import { parseUsageInfo } from "src/libraries/helpers/parseUsageInfo";
+import { RawUsageInfo, UsageInfo } from "src/libraries/types/savedata/usageInfo";
+
+describe("parseUsageInfo", () => {
+    it("should parse raw usage info with date strings to Date objects", () => {
+        const rawUsageInfo: RawUsageInfo = {
+            firstUsed: "2023-01-01T10:00:00.000Z",
+            lastUsed: "2023-01-02T15:30:00.000Z",
+            useCount: 5
+        };
+
+        const result = parseUsageInfo(rawUsageInfo);
+
+        expect(result.firstUsed).toEqual(new Date("2023-01-01T10:00:00.000Z"));
+        expect(result.lastUsed).toEqual(new Date("2023-01-02T15:30:00.000Z"));
+        expect(result.useCount).toBe(5);
+    });
+
+    it("should preserve additional properties from the input object", () => {
+        const rawUsageInfoWithExtra = {
+            firstUsed: "2023-01-01T10:00:00.000Z",
+            lastUsed: "2023-01-02T15:30:00.000Z",
+            useCount: 3,
+            extraProperty: "test",
+            anotherProp: 42
+        };
+
+        const result = parseUsageInfo(rawUsageInfoWithExtra);
+
+        expect(result.firstUsed).toEqual(new Date("2023-01-01T10:00:00.000Z"));
+        expect(result.lastUsed).toEqual(new Date("2023-01-02T15:30:00.000Z"));
+        expect(result.useCount).toBe(3);
+        expect(result.extraProperty).toBe("test");
+        expect(result.anotherProp).toBe(42);
+    });
+
+    it("should handle ISO date strings without milliseconds", () => {
+        const rawUsageInfo: RawUsageInfo = {
+            firstUsed: "2023-01-01T10:00:00Z",
+            lastUsed: "2023-01-02T15:30:00Z",
+            useCount: 1
+        };
+
+        const result = parseUsageInfo(rawUsageInfo);
+
+        expect(result.firstUsed).toEqual(new Date("2023-01-01T10:00:00Z"));
+        expect(result.lastUsed).toEqual(new Date("2023-01-02T15:30:00Z"));
+    });
+
+    it("should handle dates with timezone offsets", () => {
+        const rawUsageInfo: RawUsageInfo = {
+            firstUsed: "2023-01-01T10:00:00+02:00",
+            lastUsed: "2023-01-02T15:30:00-05:00",
+            useCount: 2
+        };
+
+        const result = parseUsageInfo(rawUsageInfo);
+
+        expect(result.firstUsed).toEqual(new Date("2023-01-01T10:00:00+02:00"));
+        expect(result.lastUsed).toEqual(new Date("2023-01-02T15:30:00-05:00"));
+    });
+
+    it("should handle zero use count", () => {
+        const rawUsageInfo: RawUsageInfo = {
+            firstUsed: "2023-01-01T10:00:00.000Z",
+            lastUsed: "2023-01-01T10:00:00.000Z",
+            useCount: 0
+        };
+
+        const result = parseUsageInfo(rawUsageInfo);
+
+        expect(result.useCount).toBe(0);
+        expect(result.firstUsed).toEqual(result.lastUsed);
+    });
+
+    it("should handle same first and last used dates", () => {
+        const sameDate = "2023-01-01T10:00:00.000Z";
+        const rawUsageInfo: RawUsageInfo = {
+            firstUsed: sameDate,
+            lastUsed: sameDate,
+            useCount: 1
+        };
+
+        const result = parseUsageInfo(rawUsageInfo);
+
+        expect(result.firstUsed).toEqual(result.lastUsed);
+        expect(result.firstUsed).toEqual(new Date(sameDate));
+    });
+});

--- a/tests/libraries/helpers/serializeFavoriteInfo.spec.ts
+++ b/tests/libraries/helpers/serializeFavoriteInfo.spec.ts
@@ -1,0 +1,81 @@
+import { serializeFavoriteInfo } from "src/libraries/helpers/serializeFavoriteInfo";
+import { FavoriteInfo, ParsedFavoriteInfo } from "src/libraries/types/savedata/favoriteInfo";
+
+describe("serializeFavoriteInfo", () => {
+    it("should serialize favorite info with Date object to date string", () => {
+        const favoriteInfo: ParsedFavoriteInfo = {
+            added: new Date("2023-01-01T10:00:00.000Z"),
+            hotkey: true
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfo);
+
+        expect(result.added).toBe("2023-01-01T10:00:00.000Z");
+        expect(result.hotkey).toBe(true);
+    });
+
+    it("should preserve additional properties from the input object", () => {
+        const favoriteInfoWithExtra = {
+            added: new Date("2023-01-01T10:00:00.000Z"),
+            hotkey: false,
+            extraProperty: "test",
+            anotherProp: 42
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfoWithExtra);
+
+        expect(result.added).toBe("2023-01-01T10:00:00.000Z");
+        expect(result.hotkey).toBe(false);
+        expect(result.extraProperty).toBe("test");
+        expect(result.anotherProp).toBe(42);
+    });
+
+    it("should handle dates with different timezones correctly", () => {
+        const favoriteInfo: ParsedFavoriteInfo = {
+            added: new Date("2023-01-01T10:00:00+02:00"),
+            hotkey: true
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfo);
+
+        // Date should be serialized to ISO string in UTC
+        expect(result.added).toBe(new Date("2023-01-01T10:00:00+02:00").toJSON());
+    });
+
+    it("should handle hotkey false", () => {
+        const favoriteInfo: ParsedFavoriteInfo = {
+            added: new Date("2023-01-01T10:00:00.000Z"),
+            hotkey: false
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfo);
+
+        expect(result.hotkey).toBe(false);
+        expect(result.added).toBe("2023-01-01T10:00:00.000Z");
+    });
+
+    it("should handle hotkey true", () => {
+        const favoriteInfo: ParsedFavoriteInfo = {
+            added: new Date("2023-01-01T10:00:00.000Z"),
+            hotkey: true
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfo);
+
+        expect(result.hotkey).toBe(true);
+        expect(result.added).toBe("2023-01-01T10:00:00.000Z");
+    });
+
+    it("should serialize type correctly", () => {
+        const favoriteInfo: ParsedFavoriteInfo = {
+            added: new Date("2023-01-01T10:00:00.000Z"),
+            hotkey: true
+        };
+
+        const result = serializeFavoriteInfo(favoriteInfo);
+
+        // Verify serialized format
+        expect(typeof result.added).toBe("string");
+        expect(typeof result.hotkey).toBe("boolean");
+    });
+});

--- a/tests/libraries/helpers/serializeUsageInfo.spec.ts
+++ b/tests/libraries/helpers/serializeUsageInfo.spec.ts
@@ -1,0 +1,99 @@
+import { serializeUsageInfo } from "src/libraries/helpers/serializeUsageInfo";
+import { RawUsageInfo, UsageInfo } from "src/libraries/types/savedata/usageInfo";
+
+describe("serializeUsageInfo", () => {
+    it("should serialize usage info with Date objects to date strings", () => {
+        const usageInfo: UsageInfo = {
+            firstUsed: new Date("2023-01-01T10:00:00.000Z"),
+            lastUsed: new Date("2023-01-02T15:30:00.000Z"),
+            useCount: 5
+        };
+
+        const result = serializeUsageInfo(usageInfo);
+
+        expect(result.firstUsed).toBe("2023-01-01T10:00:00.000Z");
+        expect(result.lastUsed).toBe("2023-01-02T15:30:00.000Z");
+        expect(result.useCount).toBe(5);
+    });
+
+    it("should preserve additional properties from the input object", () => {
+        const usageInfoWithExtra = {
+            firstUsed: new Date("2023-01-01T10:00:00.000Z"),
+            lastUsed: new Date("2023-01-02T15:30:00.000Z"),
+            useCount: 3,
+            extraProperty: "test",
+            anotherProp: 42
+        };
+
+        const result = serializeUsageInfo(usageInfoWithExtra);
+
+        expect(result.firstUsed).toBe("2023-01-01T10:00:00.000Z");
+        expect(result.lastUsed).toBe("2023-01-02T15:30:00.000Z");
+        expect(result.useCount).toBe(3);
+        expect(result.extraProperty).toBe("test");
+        expect(result.anotherProp).toBe(42);
+    });
+
+    it("should handle dates with different timezones correctly", () => {
+        const usageInfo: UsageInfo = {
+            firstUsed: new Date("2023-01-01T10:00:00+02:00"),
+            lastUsed: new Date("2023-01-02T15:30:00-05:00"),
+            useCount: 2
+        };
+
+        const result = serializeUsageInfo(usageInfo);
+
+        // Dates should be serialized to ISO strings in UTC
+        expect(result.firstUsed).toBe(new Date("2023-01-01T10:00:00+02:00").toJSON());
+        expect(result.lastUsed).toBe(new Date("2023-01-02T15:30:00-05:00").toJSON());
+    });
+
+    it("should handle zero use count", () => {
+        const usageInfo: UsageInfo = {
+            firstUsed: new Date("2023-01-01T10:00:00.000Z"),
+            lastUsed: new Date("2023-01-01T10:00:00.000Z"),
+            useCount: 0
+        };
+
+        const result = serializeUsageInfo(usageInfo);
+
+        expect(result.useCount).toBe(0);
+        expect(result.firstUsed).toBe(result.lastUsed);
+    });
+
+    it("should handle same first and last used dates", () => {
+        const sameDate = new Date("2023-01-01T10:00:00.000Z");
+        const usageInfo: UsageInfo = {
+            firstUsed: sameDate,
+            lastUsed: sameDate,
+            useCount: 1
+        };
+
+        const result = serializeUsageInfo(usageInfo);
+
+        expect(result.firstUsed).toBe(result.lastUsed);
+        expect(result.firstUsed).toBe("2023-01-01T10:00:00.000Z");
+    });
+
+    it("should roundtrip correctly with parseUsageInfo", () => {
+        const originalUsageInfo: UsageInfo = {
+            firstUsed: new Date("2023-01-01T10:00:00.000Z"),
+            lastUsed: new Date("2023-01-02T15:30:00.000Z"),
+            useCount: 5
+        };
+
+        const serialized = serializeUsageInfo(originalUsageInfo);
+
+        // Verify serialized format
+        expect(typeof serialized.firstUsed).toBe("string");
+        expect(typeof serialized.lastUsed).toBe("string");
+
+        // Import parseUsageInfo to test roundtrip
+        const { parseUsageInfo } = require("../../../src/libraries/helpers/parseUsageInfo");
+        const parsed = parseUsageInfo(serialized);
+
+        expect(parsed.firstUsed).toEqual(originalUsageInfo.firstUsed);
+        expect(parsed.lastUsed).toEqual(originalUsageInfo.lastUsed);
+        expect(parsed.useCount).toBe(originalUsageInfo.useCount);
+    });
+});

--- a/tests/libraries/helpers/toNullMatch.spec.ts
+++ b/tests/libraries/helpers/toNullMatch.spec.ts
@@ -1,0 +1,111 @@
+import { toNullMatch } from "src/libraries/helpers/toNullMatch";
+import { MaybeUsedCharacter, Character } from "src/libraries/types/codepoint/character";
+
+describe("toNullMatch", () => {
+    it("should convert character to MaybeMetaCharacterSearchResult with null matches", () => {
+        const character: Character = {
+            codepoint: "A",
+            name: "LATIN CAPITAL LETTER A",
+            category: "Lu"
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle character with usage information", () => {
+        const character: MaybeUsedCharacter = {
+            codepoint: "A",
+            name: "LATIN CAPITAL LETTER A",
+            category: "Lu",
+            useCount: 5,
+            firstUsed: new Date("2023-01-01"),
+            lastUsed: new Date("2023-01-02")
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle basic character without usage info", () => {
+        const character: Character = {
+            codepoint: "€",
+            name: "EURO SIGN",
+            category: "Sc"
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle character with zero usage", () => {
+        const character: MaybeUsedCharacter = {
+            codepoint: "B",
+            name: "LATIN CAPITAL LETTER B",
+            category: "Lu",
+            useCount: 0,
+            firstUsed: new Date("2023-01-01"),
+            lastUsed: new Date("2023-01-01")
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle character with high usage", () => {
+        const character: MaybeUsedCharacter = {
+            codepoint: "C",
+            name: "LATIN CAPITAL LETTER C",
+            category: "Lu",
+            useCount: 100,
+            firstUsed: new Date("2023-01-01"),
+            lastUsed: new Date("2023-01-02")
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle special characters", () => {
+        const character: Character = {
+            codepoint: "🚀",
+            name: "ROCKET",
+            category: "So"
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+
+    it("should handle characters with empty names", () => {
+        const character: Character = {
+            codepoint: " ",
+            name: "SPACE",
+            category: "Zs"
+        };
+
+        const result = toNullMatch(character);
+
+        expect(result.character).toBe(character);
+        expect(result.match.codepoint).toBeNull();
+        expect(result.match.name).toBeNull();
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
 			"ES5",
 			"ES6",
 			"ES7"
-		]
+		],
+		"esModuleInterop": true
 	},
 	"include": [
 		"**/*.ts"


### PR DESCRIPTION
This pull request updates the plugin version to `0.7.3` and fixes Unicode character handling, fixing #15  (again).

* Removed the assumption that NFC normalization guarantees a maximum string length of 2 for Unicode codepoints.
* Updated the type guard function `isChar` in `src/libraries/helpers/isTypeSaveData.ts` to remove the length check, allowing for codepoints longer than 2 characters after normalization.

Furthermore, it also adds regression tests for utility functions.